### PR TITLE
fix(script): avoid empty version when call release api

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -39,14 +39,17 @@ get_downloads_dir() {
 # Get latest version
 get_latest_version() {
     echo -e "${CYAN}ℹ️ Checking latest version...${NC}"
-    local latest_release
-    latest_release=$(curl -s https://api.github.com/repos/yeongpin/cursor-free-vip/releases/latest)
-    if [ $? -ne 0 ]; then
+    latest_release=$(curl -s https://api.github.com/repos/yeongpin/cursor-free-vip/releases/latest) || {
         echo -e "${RED}❌ Cannot get latest version information${NC}"
         exit 1
-    fi
+    }
     
     VERSION=$(echo "$latest_release" | grep -o '"tag_name": ".*"' | cut -d'"' -f4 | tr -d 'v')
+    if [ -z "$VERSION" ]; then
+        echo -e "${RED}❌ Failed to parse version from GitHub API response:\n${latest_release}"
+        exit 1
+    fi
+
     echo -e "${GREEN}✅ Found latest version: ${VERSION}${NC}"
 }
 
@@ -170,9 +173,7 @@ install_cursor_free_vip() {
     fi
     
     echo -e "${CYAN}ℹ️ Setting executable permissions...${NC}"
-    chmod +x "${binary_path}"
-    
-    if [ $? -eq 0 ]; then
+    if chmod +x "${binary_path}"; then
         echo -e "${GREEN}✅ Installation completed!${NC}"
         echo -e "${CYAN}ℹ️ Program downloaded to: ${binary_path}${NC}"
         echo -e "${CYAN}ℹ️ Starting program...${NC}"


### PR DESCRIPTION
Issue Context:
When we use a public IP or proxy IP, Github is likely to prohibit us from calling its API without authentication, like ↓

**Before:**
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/9e7f2c6f-34a0-4c21-8f61-d72b83579a28" />
print the resp/log :
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/22655e49-f279-4c09-a91e-fdf53781afd3" />

And we will grep a empty str for `VERSION` causing installation failure without error info/resp

**After:**
<img width="1469" alt="image" src="https://github.com/user-attachments/assets/5c95d5fa-5dac-4c99-8a5c-9bec5c4ccca9" />


And also we could add a note in the issue/doc to tell users to try switching IP addresses or proxies (Optional)