### PR TITLE
fix: Update Linux machineId path to use lowercase cursor/machineid

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ storage_path = /Users/username/Library/Application Support/Cursor/User/globalSto
 sqlite_path = /Users/username/Library/Application Support/Cursor/User/globalStorage/state.vscdb
 # Machine ID Path | 機器ID路徑
 machine_id_path = /Users/username/Library/Application Support/Cursor/machineId
+# For Linux users: ~/.config/cursor/machineid
 
 [Timing]
 # Min Random Time | 最小隨機時間

--- a/config.py
+++ b/config.py
@@ -64,9 +64,9 @@ def setup_config(translator=None):
             actual_home = f"/home/{sudo_user}" if sudo_user else os.path.expanduser("~")
             
             default_config['LinuxPaths'] = {
-                'storage_path': os.path.abspath(os.path.join(actual_home, ".config/Cursor/User/globalStorage/storage.json")),
-                'sqlite_path': os.path.abspath(os.path.join(actual_home, ".config/Cursor/User/globalStorage/state.vscdb")),
-                'machine_id_path': os.path.expanduser("~/.config/Cursor/machineId"),
+                'storage_path': os.path.abspath(os.path.join(actual_home, ".config/cursor/User/globalStorage/storage.json")),
+                'sqlite_path': os.path.abspath(os.path.join(actual_home, ".config/cursor/User/globalStorage/state.vscdb")),
+                'machine_id_path': os.path.expanduser("~/.config/cursor/machineid"),
                 'cursor_path': get_linux_cursor_path(),
                 'updater_path': os.path.expanduser("~/.config/cursor-updater")
             }

--- a/reset_machine_manual.py
+++ b/reset_machine_manual.py
@@ -96,7 +96,7 @@ def get_cursor_machine_id_path(translator=None) -> str:
         if not config.has_section('LinuxPaths'):
             config.add_section('LinuxPaths')
             config.set('LinuxPaths', 'machine_id_path',
-                os.path.expanduser("~/.config/Cursor/machineId"))
+                os.path.expanduser("~/.config/cursor/machineid"))
         return config.get('LinuxPaths', 'machine_id_path')
         
     elif sys.platform == "darwin":  # macOS
@@ -451,11 +451,11 @@ class MachineIDResetter:
                 
                 config.set('LinuxPaths', 'storage_path', os.path.abspath(os.path.join(
                     actual_home,
-                    ".config/Cursor/User/globalStorage/storage.json"
+                    ".config/cursor/User/globalStorage/storage.json"
                 )))
                 config.set('LinuxPaths', 'sqlite_path', os.path.abspath(os.path.join(
                     actual_home,
-                    ".config/Cursor/User/globalStorage/state.vscdb"
+                    ".config/cursor/User/globalStorage/state.vscdb"
                 )))
                 
             self.db_path = config.get('LinuxPaths', 'storage_path')


### PR DESCRIPTION
This PR fixes issues with the Linux machineId path by:

1. Changing the directory from `~/.config/Cursor` to `~/.config/cursor`
2. Changing the filename from `machineId` to `machineid`
3. Updated all related paths in:
   - reset_machine_manual.py
   - config.py
   - Added Linux path note in README.md

These changes align with Linux filesystem conventions and fix issues with Chrome/Chromium integration.
#337 