### PR TITLE
Fix forced update config deletion when update check is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## v1.8.09
+1. Add: Force Update Config | 添加強制更新配置
+2. Add: Multilanguage support for force update | 添加強制更新功能的多語言支持
+3. Fix: Some Issues | 修復一些問題
+
 ## v1.8.08
 1. Add: Force Update Config | 添加強制更新配置
 2. Add: Multilanguage support for force update | 添加強制更新功能的多語言支持

--- a/config.py
+++ b/config.py
@@ -261,7 +261,7 @@ def print_config(config, translator=None):
 
 def force_update_config(translator=None):
     """
-    Force update configuration file with latest defaults
+    Force update configuration file with latest defaults if update check is enabled.
     Args:
         translator: Translator instance
     Returns:
@@ -271,26 +271,39 @@ def force_update_config(translator=None):
         config_dir = os.path.join(get_user_documents_path(), ".cursor-free-vip")
         config_file = os.path.join(config_dir, "config.ini")
         current_time = datetime.datetime.now()
-        
+
+        # If the config file exists, check if forced update is enabled
         if os.path.exists(config_file):
-            try:
-                # create backup
-                backup_file = f"{config_file}.bak.{current_time.strftime('%Y%m%d_%H%M%S')}"
-                shutil.copy2(config_file, backup_file)
+            # First, read the existing configuration
+            existing_config = configparser.ConfigParser()
+            existing_config.read(config_file, encoding='utf-8')
+            # Check if "enabled_update_check" is True
+            update_enabled = True  # Default to True if not set
+            if existing_config.has_section('Utils') and existing_config.has_option('Utils', 'enabled_update_check'):
+                update_enabled = existing_config.get('Utils', 'enabled_update_check').strip().lower() in ('true', 'yes', '1', 'on')
+
+            if update_enabled:
+                try:
+                    # Create a backup
+                    backup_file = f"{config_file}.bak.{current_time.strftime('%Y%m%d_%H%M%S')}"
+                    shutil.copy2(config_file, backup_file)
+                    if translator:
+                        print(f"{Fore.CYAN}{EMOJI['INFO']} {translator.get('config.backup_created', path=backup_file) if translator else f'Backup created: {backup_file}'}{Style.RESET_ALL}")
+
+                    # Delete the original config file (forced update)
+                    os.remove(config_file)
+                    if translator:
+                        print(f"{Fore.CYAN}{EMOJI['INFO']} {translator.get('config.config_removed') if translator else 'Config file removed for forced update'}{Style.RESET_ALL}")
+                except Exception as e:
+                    if translator:
+                        print(f"{Fore.RED}{EMOJI['ERROR']} {translator.get('config.backup_failed', error=str(e)) if translator else f'Failed to backup config: {str(e)}'}{Style.RESET_ALL}")
+            else:
                 if translator:
-                    print(f"{Fore.CYAN}{EMOJI['INFO']} {translator.get('config.backup_created', path=backup_file) if translator else f'Backup created: {backup_file}'}{Style.RESET_ALL}")
-                
-                # delete original file
-                os.remove(config_file)
-                if translator:
-                    print(f"{Fore.CYAN}{EMOJI['INFO']} {translator.get('config.config_removed') if translator else 'Config file removed for forced update'}{Style.RESET_ALL}")
-            except Exception as e:
-                if translator:
-                    print(f"{Fore.RED}{EMOJI['ERROR']} {translator.get('config.backup_failed', error=str(e)) if translator else f'Failed to backup config: {str(e)}'}{Style.RESET_ALL}")
-        
-        # use existing setup_config function to create new config
+                    print(f"{Fore.CYAN}{EMOJI['INFO']} {translator.get('config.force_update_disabled', fallback='Force update disabled by configuration. Keeping existing config file.') if translator else 'Force update disabled by configuration. Keeping existing config file.'}{Style.RESET_ALL}")
+
+        # Generate a new (or updated) configuration if needed
         return setup_config(translator)
-    
+
     except Exception as e:
         if translator:
             print(f"{Fore.RED}{EMOJI['ERROR']} {translator.get('config.force_update_failed', error=str(e)) if translator else f'Force update config failed: {str(e)}'}{Style.RESET_ALL}")

--- a/config.py
+++ b/config.py
@@ -54,6 +54,7 @@ def setup_config(translator=None):
             },
             'Utils': {
                 'enabled_update_check': 'True',
+                'enabled_force_update': 'True',
                 'enabled_account_info': 'True'
             }
         }
@@ -279,8 +280,8 @@ def force_update_config(translator=None):
             existing_config.read(config_file, encoding='utf-8')
             # Check if "enabled_update_check" is True
             update_enabled = True  # Default to True if not set
-            if existing_config.has_section('Utils') and existing_config.has_option('Utils', 'enabled_update_check'):
-                update_enabled = existing_config.get('Utils', 'enabled_update_check').strip().lower() in ('true', 'yes', '1', 'on')
+            if existing_config.has_section('Utils') and existing_config.has_option('Utils', 'enabled_force_update'):
+                update_enabled = existing_config.get('Utils', 'enabled_force_update').strip().lower() in ('true', 'yes', '1', 'on')
 
             if update_enabled:
                 try:
@@ -288,8 +289,8 @@ def force_update_config(translator=None):
                     backup_file = f"{config_file}.bak.{current_time.strftime('%Y%m%d_%H%M%S')}"
                     shutil.copy2(config_file, backup_file)
                     if translator:
-                        print(f"{Fore.CYAN}{EMOJI['INFO']} {translator.get('config.backup_created', path=backup_file) if translator else f'Backup created: {backup_file}'}{Style.RESET_ALL}")
-
+                        print(f"\n{Fore.CYAN}{EMOJI['INFO']} {translator.get('config.backup_created', path=backup_file) if translator else f'Backup created: {backup_file}'}{Style.RESET_ALL}")
+                    print(f"\n{Fore.CYAN}{EMOJI['INFO']} {translator.get('config.config_force_update_enabled') if translator else 'Config file force update enabled'}{Style.RESET_ALL}")
                     # Delete the original config file (forced update)
                     os.remove(config_file)
                     if translator:
@@ -299,7 +300,7 @@ def force_update_config(translator=None):
                         print(f"{Fore.RED}{EMOJI['ERROR']} {translator.get('config.backup_failed', error=str(e)) if translator else f'Failed to backup config: {str(e)}'}{Style.RESET_ALL}")
             else:
                 if translator:
-                    print(f"{Fore.CYAN}{EMOJI['INFO']} {translator.get('config.force_update_disabled', fallback='Force update disabled by configuration. Keeping existing config file.') if translator else 'Force update disabled by configuration. Keeping existing config file.'}{Style.RESET_ALL}")
+                    print(f"\n{Fore.CYAN}{EMOJI['INFO']} {translator.get('config.config_force_update_disabled', fallback='Config file force update disabled by configuration. Keeping existing config file.') if translator else 'Config file force update disabled by configuration. Keeping existing config file.'}{Style.RESET_ALL}")
 
         # Generate a new (or updated) configuration if needed
         return setup_config(translator)

--- a/locales/en.json
+++ b/locales/en.json
@@ -560,7 +560,9 @@
         "backup_created": "Backup created: {path}",
         "config_removed": "Config file removed for forced update",
         "backup_failed": "Failed to backup config: {error}",
-        "force_update_failed": "Force update config failed: {error}"
+        "force_update_failed": "Force update config failed: {error}",
+        "config_force_update_disabled": "Config file force update disabled , skipping forced update",
+        "config_force_update_enabled": "Config file force update enabled , performing forced update"
     },
     "oauth": {
         "authentication_button_not_found": "Authentication button not found",

--- a/locales/zh_cn.json
+++ b/locales/zh_cn.json
@@ -538,7 +538,9 @@
         "backup_created": "备份创建: {path}",
         "config_removed": "配置文件已删除用于强制更新",
         "backup_failed": "备份失败: {error}",
-        "force_update_failed": "强制更新配置失败: {error}"
+        "force_update_failed": "强制更新配置失败: {error}",
+        "config_force_update_disabled": "配置文件强制更新已禁用，跳过强制更新",
+        "config_force_update_enabled": "配置文件强制更新已启用，正在执行强制更新"
     },
     "oauth": {
         "authentication_button_not_found": "未找到认证按钮",

--- a/locales/zh_tw.json
+++ b/locales/zh_tw.json
@@ -520,7 +520,9 @@
         "backup_created": "備份已創建: {path}",
         "config_removed": "配置文件已刪除用於強制更新",
         "backup_failed": "備份失敗: {error}",
-        "force_update_failed": "強制更新配置失敗: {error}"
+        "force_update_failed": "強制更新配置失敗: {error}",
+        "config_force_update_disabled": "配置文件強制更新已禁用，跳過強制更新",
+        "config_force_update_enabled": "配置文件強制更新已啟用，正在執行強制更新"
     },
     "oauth": {
         "authentication_button_not_found": "未找到認證按鈕",


### PR DESCRIPTION
- Added a conditional check in force_update_config() to verify that enabled_update_check in the [Utils] section is read as False.
- If disabled, the config file will not be deleted.
- This prevents loss of custom configuration and improves usability.
- Tested on macOS with our modifications.