### PR TITLE
Fix ChromiumOptions.arguments type error: list object has no attribute 'get'

### DIFF
--- a/new_tempemail.py
+++ b/new_tempemail.py
@@ -139,7 +139,7 @@ class NewTempEmail:
 
             if sys.platform == "linux":
                 # Check if DISPLAY is set when not in headless mode
-                if not co.arguments.get("--headless=new") and not os.environ.get('DISPLAY'):
+                if "--headless=new" not in co.arguments and not os.environ.get('DISPLAY'):
                     print(f"{Fore.RED}❌ {self.translator.get('email.no_display_found') if self.translator else 'No display found. Make sure X server is running.'}{Style.RESET_ALL}")
                     print(f"{Fore.YELLOW}ℹ️ {self.translator.get('email.try_export_display') if self.translator else 'Try: export DISPLAY=:0'}{Style.RESET_ALL}")
                     return False


### PR DESCRIPTION
**Summary:**
This PR fixes a TypeError caused by incorrect usage of the get method on the ChromiumOptions.arguments object, which is a list, not a dict. The condition attempting to call co.arguments.get("--headless=new") would raise an exception. This has been corrected by replacing it with the appropriate list membership check.

**Changes:**

Replaced the invalid method call `co.arguments.get("--headless=new")` with `"--headless=new" not in co.arguments` in *new_tempemail.py* to correctly check for argument presence in the list.

**Related Issue:**

Fixes #583