### PR TITLE
新增TempMailPlus配置，支持临时邮箱验证功能

### DIFF
--- a/config.py
+++ b/config.py
@@ -249,6 +249,13 @@ def setup_config(translator=None):
                 'product_json_path': os.path.join(cursor_dir, "resources/app/product.json") if cursor_dir else ""
             }
 
+        # Add tempmail_plus configuration
+        default_config['TempMailPlus'] = {
+            'enabled': 'false',
+            'email': '',
+            'epin': ''
+        }
+
         # Read existing configuration and merge
         if os.path.exists(config_file):
             config.read(config_file, encoding='utf-8')

--- a/cursor_register_manual.py
+++ b/cursor_register_manual.py
@@ -6,6 +6,7 @@ from faker import Faker
 from cursor_auth import CursorAuth
 from reset_machine_manual import MachineIDResetter
 from get_user_token import get_token_from_cookie
+from config import get_config
 
 os.environ["PYTHONVERBOSE"] = "0"
 os.environ["PYINSTALLER_VERBOSE"] = "0"
@@ -102,6 +103,18 @@ class CursorRegistration:
         try:
             print(f"{Fore.CYAN}{EMOJI['START']} {self.translator.get('register.register_start')}...{Style.RESET_ALL}")
             
+            # Check if tempmail_plus is enabled
+            config = get_config(self.translator)
+            email_tab = None
+            if config and config.has_section('TempMailPlus'):
+                if config.getboolean('TempMailPlus', 'enabled'):
+                    email = config.get('TempMailPlus', 'email')
+                    epin = config.get('TempMailPlus', 'epin')
+                    if email and epin:
+                        from email_tabs.tempmail_plus_tab import TempMailPlusTab
+                        email_tab = TempMailPlusTab(email, epin)
+                        print(f"{Fore.CYAN}{EMOJI['MAIL']} {self.translator.get('register.using_tempmail_plus')}{Style.RESET_ALL}")
+            
             # Use new_signup.py directly for registration
             from new_signup import main as new_signup_main
             
@@ -111,7 +124,7 @@ class CursorRegistration:
                 password=self.password,
                 first_name=self.first_name,
                 last_name=self.last_name,
-                email_tab=None,  # No email tab needed
+                email_tab=email_tab,  # Pass email_tab if tempmail_plus is enabled
                 controller=self,  # Pass self instead of self.controller
                 translator=self.translator
             )

--- a/email_tabs/email_tab_interface.py
+++ b/email_tabs/email_tab_interface.py
@@ -1,0 +1,27 @@
+from abc import ABC, abstractmethod
+
+class EmailTabInterface(ABC):
+    """Email tab interface for handling email verification"""
+    
+    @abstractmethod
+    def refresh_inbox(self) -> None:
+        """Refresh the email inbox"""
+        pass
+    
+    @abstractmethod
+    def check_for_cursor_email(self) -> bool:
+        """Check if there is a verification email from Cursor
+        
+        Returns:
+            bool: True if verification email exists, False otherwise
+        """
+        pass
+    
+    @abstractmethod
+    def get_verification_code(self) -> str:
+        """Get the verification code from the email
+        
+        Returns:
+            str: The verification code if found, empty string otherwise
+        """
+        pass

--- a/email_tabs/tempmail_plus_tab.py
+++ b/email_tabs/tempmail_plus_tab.py
@@ -1,0 +1,109 @@
+import requests
+import re
+from typing import Optional
+from .email_tab_interface import EmailTabInterface
+
+class TempMailPlusTab(EmailTabInterface):
+    """Implementation of EmailTabInterface for tempmail.plus"""
+    
+    def __init__(self, email: str, epin: str):
+        """Initialize TempMailPlusTab
+        
+        Args:
+            email: The email address to check
+            epin: The epin token for authentication
+        """
+        self.email = email
+        self.epin = epin
+        self.base_url = "https://tempmail.plus/api"
+        self.headers = {
+            'accept': 'application/json',
+            'accept-language': 'zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7,zh-TW;q=0.6',
+            'cache-control': 'no-cache',
+            'pragma': 'no-cache',
+            'referer': 'https://tempmail.plus/zh/',
+            'sec-ch-ua': '"Google Chrome";v="135", "Not-A.Brand";v="8", "Chromium";v="135"',
+            'sec-ch-ua-mobile': '?0',
+            'sec-ch-ua-platform': '"macOS"',
+            'sec-fetch-dest': 'empty',
+            'sec-fetch-mode': 'cors',
+            'sec-fetch-site': 'same-origin',
+            'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36',
+            'x-requested-with': 'XMLHttpRequest'
+        }
+        self.cookies = {'email': email}
+        self._cached_mail_id = None  # 缓存mail_id
+        
+    def refresh_inbox(self) -> None:
+        """Refresh the email inbox"""
+        pass
+            
+    def check_for_cursor_email(self) -> bool:
+        """Check if there is a verification email from Cursor
+        
+        Returns:
+            bool: True if verification email exists, False otherwise
+        """
+        try:
+            params = {
+                'email': self.email,
+                'epin': self.epin
+            }
+            response = requests.get(
+                f"{self.base_url}/mails",
+                params=params,
+                headers=self.headers,
+                cookies=self.cookies
+            )
+            response.raise_for_status()
+            
+            data = response.json()
+            if data.get('result') and data.get('mail_list'):
+                for mail in data['mail_list']:
+                    if 'cursor.sh' in mail.get('from_mail', '') and mail.get('is_new') == True:
+                        self._cached_mail_id = mail.get('mail_id')  # 缓存mail_id
+                        return True
+            return False
+        except Exception as e:
+            print(f"检查Cursor邮件失败: {str(e)}")
+            return False
+            
+    def get_verification_code(self) -> str:
+        """Get the verification code from the email
+        
+        Returns:
+            str: The verification code if found, empty string otherwise
+        """
+        try:
+            # 如果没有缓存的mail_id，先检查是否有新邮件
+            if not self._cached_mail_id:
+                if not self.check_for_cursor_email():
+                    return ""
+                    
+            # 使用缓存的mail_id获取邮件内容
+            params = {
+                'email': self.email,
+                'epin': self.epin
+            }
+            response = requests.get(
+                f"{self.base_url}/mails/{self._cached_mail_id}",
+                params=params,
+                headers=self.headers,
+                cookies=self.cookies
+            )
+            response.raise_for_status()
+            
+            data = response.json()
+            if not data.get('result'):
+                return ""
+                
+            # Extract verification code from text content using regex
+            text = data.get('text', '')
+            match = re.search(r'\n\n(\d{6})\n\n', text)
+            if match:
+                return match.group(1)
+                
+            return ""
+        except Exception as e:
+            print(f"获取验证码失败: {str(e)}")
+            return "" 

--- a/locales/en.json
+++ b/locales/en.json
@@ -211,7 +211,18 @@
         "try_install_browser": "Try installing the browser with your package manager",
         "tracking_processes": "Tracking {count} {browser} processes",
         "no_new_processes_detected": "No new {browser} processes detected to track",
-        "could_not_track_processes": "Could not track {browser} processes: {error}"
+        "could_not_track_processes": "Could not track {browser} processes: {error}",
+        "using_tempmail_plus": "Using TempMailPlus for email verification",
+        "tempmail_plus_enabled": "TempMailPlus is enabled",
+        "tempmail_plus_disabled": "TempMailPlus is disabled",
+        "tempmail_plus_config_missing": "TempMailPlus configuration is missing",
+        "tempmail_plus_email_missing": "TempMailPlus email is not configured",
+        "tempmail_plus_epin_missing": "TempMailPlus epin is not configured",
+        "tempmail_plus_initialized": "TempMailPlus initialized successfully",
+        "tempmail_plus_init_failed": "Failed to initialize TempMailPlus: {error}",
+        "tempmail_plus_verification_started": "Starting TempMailPlus verification process",
+        "tempmail_plus_verification_completed": "TempMailPlus verification completed successfully",
+        "tempmail_plus_verification_failed": "TempMailPlus verification failed: {error}"
     },
     "auth": {
         "title": "Cursor Auth Manager",

--- a/locales/zh_cn.json
+++ b/locales/zh_cn.json
@@ -211,7 +211,18 @@
         "no_new_processes_detected": "未检测到新的 {browser} 进程",
         "could_not_track_processes": "无法跟踪 {browser} 进程: {error}",
         "human_verify_error": "无法验证用户是人类，正在重试...",
-        "max_retries_reached": "已达到最大重试次数，注册失败。"
+        "max_retries_reached": "已达到最大重试次数，注册失败。",
+        "using_tempmail_plus": "使用TempMailPlus进行邮箱验证",
+        "tempmail_plus_enabled": "TempMailPlus已启用",
+        "tempmail_plus_disabled": "TempMailPlus已禁用",
+        "tempmail_plus_config_missing": "TempMailPlus配置缺失",
+        "tempmail_plus_email_missing": "未配置TempMailPlus邮箱",
+        "tempmail_plus_epin_missing": "未配置TempMailPlus epin",
+        "tempmail_plus_initialized": "TempMailPlus初始化成功",
+        "tempmail_plus_init_failed": "TempMailPlus初始化失败：{error}",
+        "tempmail_plus_verification_started": "开始TempMailPlus验证流程",
+        "tempmail_plus_verification_completed": "TempMailPlus验证成功完成",
+        "tempmail_plus_verification_failed": "TempMailPlus验证失败：{error}"
     },
     "auth": {
         "title": "Cursor 认证管理器",

--- a/locales/zh_tw.json
+++ b/locales/zh_tw.json
@@ -198,7 +198,18 @@
         "password_submitted": "密碼已提交",
         "total_usage": "總使用量: {usage}",
         "setting_on_password": "設置密碼",
-        "getting_code": "正在獲取驗證碼，將在60秒內嘗試..."
+        "getting_code": "正在獲取驗證碼，將在60秒內嘗試...",
+        "using_tempmail_plus": "使用TempMailPlus進行郵箱驗證",
+        "tempmail_plus_enabled": "TempMailPlus已啟用",
+        "tempmail_plus_disabled": "TempMailPlus已禁用",
+        "tempmail_plus_config_missing": "TempMailPlus配置缺失",
+        "tempmail_plus_email_missing": "未配置TempMailPlus郵箱",
+        "tempmail_plus_epin_missing": "未配置TempMailPlus epin",
+        "tempmail_plus_initialized": "TempMailPlus初始化成功",
+        "tempmail_plus_init_failed": "TempMailPlus初始化失敗：{error}",
+        "tempmail_plus_verification_started": "開始TempMailPlus驗證流程",
+        "tempmail_plus_verification_completed": "TempMailPlus驗證成功完成",
+        "tempmail_plus_verification_failed": "TempMailPlus驗證失敗：{error}"
     },
     "auth": {
         "title": "Cursor 認證管理器",


### PR DESCRIPTION
# 简介
本次提交补充了 `email_tab` 接口的实现。原项目中已有相关逻辑，但由于接口缺失，验证码自动接收功能暂不可用。

## 变更内容
- 基于 TempMailPlus 实现了 `email_tab`，作为临时邮箱中转服务。
- 无需改动现有逻辑，直接恢复验证码自动接收能力。

## 背景
在阅读源码时注意到，虽然项目中保留了邮箱验证码自动获取的逻辑，但缺少具体邮箱源支持。因此尝试使用 TempMailPlus 补充，实现该功能链路的完整性。

## 风险评估
- 引入的 TempMailPlus 为临时邮箱服务，若未来不可用，可快速切换其他服务。
- 本次改动不影响其他模块，侵入式极低。


## TempMailPlus 使用说明

1. 运行程序后，在「显示配置」选项中可以查看当前的配置文件路径。
2. 打开配置文件，找到 `[TempMailPlus]` 部分，进行如下配置：

```ini
[TempMailPlus]
enabled = true             # 是否启用 TempMailPlus（必填，true 开启）
email = <你在网站上生成的临时邮箱>    # 填写 TempMailPlus 提供的邮箱地址
epin = <邮箱对应的 PIN>         # 若有 PIN，填写对应 PIN；没有则可留空
```

3. 保存配置，重启程序后即会启用 TempMailPlus 接收验证码功能。

---

### 备注
- 如果需要停用 TempMailPlus，只需将 `enabled` 设置为 `false`。
