### PR TITLE
fix: 修复 Chrome 用户数据目录权限问题

### DIFF
--- a/locales/zh_cn.json
+++ b/locales/zh_cn.json
@@ -640,7 +640,9 @@
         "found_chrome_at": "找到 Chrome: {path}",
         "found_browser_user_data_dir": "找到 {browser} 用户数据目录: {path}",
         "select_profile": "选择要使用的 {browser} 配置文件：",
-        "profile_list": "可用 {browser} 配置文件："
+        "profile_list": "可用 {browser} 配置文件：",
+        "chrome_permissions_fixed": "已修复 Chrome 用户数据目录权限",
+        "chrome_permissions_fix_failed": "修复 Chrome 权限失败: {error}"
     },
     "browser_profile": {
         "title": "浏览器配置文件选择",


### PR DESCRIPTION
## 问题描述
使用 cursor-free-vip 进行 Google 账号登录后，Chrome 浏览器打开时提示："系统无法读取您的偏好设置。某些功能可能无法使用，并且对偏好设置所做的更改不会保存。"

## 原因分析
执行完登录后，文件夹 ~/Library/Application Support/Google/Chrome/ 权限发生了变化，需要重新对当前用户赋权否则无法访问个人偏好设置。

## 解决方案
1. 添加了 `_fix_chrome_permissions` 方法，用于修复 Chrome 用户数据目录的权限
2. 在浏览器关闭后自动调用此方法
3. 添加了相应的中文翻译字符串

## 测试方法
1. 关闭 Chrome 浏览器
2. 运行 cursor-free-vip 程序
3. 选择 "使用自己的Google账户注册" 选项
4. 完成 Google 账号登录流程
5. 登录完成后，程序会自动修复 Chrome 用户数据目录的权限
6. 打开 Chrome 浏览器，检查是否还会出现权限问题

## 预期结果
Chrome 浏览器可以正常访问个人偏好设置，不再出现权限错误提示。