### PR TITLE
修正 windows 环境下用户目录的获取方式

### DIFF
--- a/bypass_token_limit.py
+++ b/bypass_token_limit.py
@@ -26,7 +26,14 @@ EMOJI = {
 def get_user_documents_path():
      """Get user Documents folder path"""
      if sys.platform == "win32":
-         return os.path.join(os.path.expanduser("~"), "Documents")
+         try:
+             import winreg
+             with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders") as key:
+                 documents_path, _ = winreg.QueryValueEx(key, "Personal")
+                 return documents_path
+         except Exception as e:
+             # fallback
+             return os.path.join(os.path.expanduser("~"), "Documents")
      elif sys.platform == "darwin":
          return os.path.join(os.path.expanduser("~"), "Documents")
      else:  # Linux

--- a/new_signup.py
+++ b/new_signup.py
@@ -116,7 +116,14 @@ def fill_signup_form(page, first_name, last_name, email, config, translator=None
 def get_user_documents_path():
     """Get user Documents folder path"""
     if sys.platform == "win32":
-        return os.path.join(os.path.expanduser("~"), "Documents")
+        try:
+            import winreg
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders") as key:
+                documents_path, _ = winreg.QueryValueEx(key, "Personal")
+                return documents_path
+        except Exception as e:
+            # fallback
+            return os.path.join(os.path.expanduser("~"), "Documents")
     elif sys.platform == "darwin":
         return os.path.join(os.path.expanduser("~"), "Documents")
     else:  # Linux

--- a/reset_machine_manual.py
+++ b/reset_machine_manual.py
@@ -33,7 +33,14 @@ EMOJI = {
 def get_user_documents_path():
      """Get user Documents folder path"""
      if sys.platform == "win32":
-         return os.path.join(os.path.expanduser("~"), "Documents")
+         try:
+             import winreg
+             with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders") as key:
+                 documents_path, _ = winreg.QueryValueEx(key, "Personal")
+                 return documents_path
+         except Exception as e:
+             # fallback
+             return os.path.join(os.path.expanduser("~"), "Documents")
      elif sys.platform == "darwin":
          return os.path.join(os.path.expanduser("~"), "Documents")
      else:  # Linux

--- a/totally_reset_cursor.py
+++ b/totally_reset_cursor.py
@@ -32,7 +32,13 @@ EMOJI = {
 def get_user_documents_path():
      """Get user Documents folder path"""
      if sys.platform == "win32":
-         return os.path.join(os.path.expanduser("~"), "Documents")
+         try:
+             import winreg
+             with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders") as key:
+                 documents_path, _ = winreg.QueryValueEx(key, "Personal")
+                 return documents_path
+         except Exception as e:
+             return os.path.join(os.path.expanduser("~"), "Documents")
      elif sys.platform == "darwin":
          return os.path.join(os.path.expanduser("~"), "Documents")
      else:  # Linux

--- a/utils.py
+++ b/utils.py
@@ -6,7 +6,16 @@ import random
 def get_user_documents_path():
     """Get user documents path"""
     if platform.system() == "Windows":
-        return os.path.expanduser("~\\Documents")
+        try:
+            import winreg
+            # 打开注册表
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders") as key:
+                # 获取 "Personal" 键的值，这指向用户的文档目录
+                documents_path, _ = winreg.QueryValueEx(key, "Personal")
+                return documents_path
+        except Exception as e:
+            # fallback
+            return os.path.expanduser("~\\Documents")
     else:
         return os.path.expanduser("~/Documents")
     


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/078cdb66-6d7d-44de-8341-d072f79eff91)

用户可能通过右键文档，在属性页面修改了实际路径。所以用户文档目录不一定只在 C:/Users/用户名/Documents。应该通过注册表来获取用户目录。

另外，由于 winreg 模块仅存在于 windows 环境，所以 import 语句放进了条件分支内部。