### PR TITLE
在配置中更新 User-Agent 和使用 API URL

### DIFF
--- a/cursor_acc_info.py
+++ b/cursor_acc_info.py
@@ -35,7 +35,7 @@ class Config:
     NAME_LOWER = "cursor"
     NAME_CAPITALIZE = "Cursor"
     BASE_HEADERS = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
         "Accept": "application/json",
         "Content-Type": "application/json"
     }
@@ -55,7 +55,7 @@ class UsageManager:
     @staticmethod
     def get_usage(token: str) -> Optional[Dict]:
         """get usage"""
-        url = f"https://www.{Config.NAME_LOWER}.com/api/usage"
+        url = f"https://{Config.NAME_LOWER}.com/api/usage"
         headers = Config.BASE_HEADERS.copy()
         headers.update({"Cookie": f"Workos{Config.NAME_CAPITALIZE}SessionToken=user_01OOOOOOOOOOOOOOOOOOOOOOOO%3A%3A{token}"})
         try:


### PR DESCRIPTION
## English

**Title:**  
Update User-Agent in Config and Use API URL

**Description:**  
- Updated the User-Agent string in `BASE_HEADERS` to use a newer Chrome version.
- Removed "www." from the API URL to match the correct endpoint.

---

## 中文

**标题：**  
在配置中更新 User-Agent 和使用 API URL

**描述：**  
- 将 `BASE_HEADERS` 中的 User-Agent 字符串更新为较新的 Chrome 版本。
- 从 API URL 中删除了“www.”，以匹配正确的端点。